### PR TITLE
Pulled up PageObject methods to superclass. Allows the removal of TPa…

### DIFF
--- a/src/Passenger/PageObject.cs
+++ b/src/Passenger/PageObject.cs
@@ -9,27 +9,6 @@ namespace Passenger
     {
         public PassengerConfiguration Configuration { get; set; }
         public object CurrentProxy { get; set; }
-    }
-    
-    public class PageObject<TPageObjectType> 
-        : PageObject, IDisposable where TPageObjectType : class
-    {
-        public PageObject()
-        {
-        }
-
-        public PageObject(PassengerConfiguration configuration, TPageObjectType currentProxy)
-        {
-            Configuration = configuration;
-            CurrentProxy = currentProxy;
-        }
-
-        public PageObject(PassengerConfiguration configuration)
-        {
-            Configuration = configuration;
-
-            GoTo<TPageObjectType>();
-        }
 
         public TNextPageObjectType GoTo<TNextPageObjectType>() where TNextPageObjectType : class
         {
@@ -88,6 +67,27 @@ namespace Passenger
         public void Dispose()
         {
             Configuration.Driver.Dispose();
+        }
+    }
+    
+    public class PageObject<TPageObjectType> 
+        : PageObject, IDisposable where TPageObjectType : class
+    {
+        public PageObject()
+        {
+        }
+
+        public PageObject(PassengerConfiguration configuration, TPageObjectType currentProxy)
+        {
+            Configuration = configuration;
+            CurrentProxy = currentProxy;
+        }
+
+        public PageObject(PassengerConfiguration configuration)
+        {
+            Configuration = configuration;
+
+            GoTo<TPageObjectType>();
         }
     }
 }


### PR DESCRIPTION
…geObjectType dependency

Hi David,

I was creating a test framework for our services based on your excellent Passenger library but couldn't remove the e.g. SignInPage generic type dependency when creating a PageObject for the Context field.

    protected static PageObject<SingInPage> Context;

Pulling up the methods to the super PageObject class allowed its removal:

    protected static PageObject Context;

Which is now set like so:

    Context = passengerConfiguration.StartTestAt<SignInPage>();

And works a treat.  I've been able to create a nice fluent test framework which I plan to release if you are able to incorporate this PR into your project.

All your tests pass, I haven't added any further tests.  If there are any issues this change may cause which I haven't thought of please let me know!

Have actually had fun writing acceptance tests with Passenger.

Thank you.